### PR TITLE
Improve fetch error handling

### DIFF
--- a/src/nanoleaf4dAccessory.mts
+++ b/src/nanoleaf4dAccessory.mts
@@ -116,7 +116,14 @@ export class Nanoleaf4dAccessory {
     }
 
     const { host, port, token } = this.accessory.context;
-    const response = await fetch(`http://${host}:${port}/api/v1/${token}/${path}`, req);
+    let response: Response;
+    try {
+      response = await fetch(`http://${host}:${port}/api/v1/${token}/${path}`, req);
+    } catch (err) {
+      const msg = `Network error calling accessory at ${host}:${port}`;
+      this.platform.log(msg, err);
+      throw new Error(`${msg}: ${err instanceof Error ? err.message : String(err)}`);
+    }
 
     if (!response.ok) {
       const msg = `Error response calling accessory: (${response.status}) ${await response.text()}`;

--- a/src/platform.mts
+++ b/src/platform.mts
@@ -10,7 +10,7 @@ import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
  * Nanoleaf 4D instance.
  */
 export class Nanoleaf4DPlatform implements DynamicPlatformPlugin {
-  private readonly client: Nanoleaf4DClient = new Nanoleaf4DClient();
+  private readonly client: Nanoleaf4DClient;
   public readonly Service: typeof Service;
   public readonly Characteristic: typeof Characteristic;
 
@@ -22,6 +22,7 @@ export class Nanoleaf4DPlatform implements DynamicPlatformPlugin {
     public readonly config: Nanoleaf4DPlatformConfig,
     public readonly api: API,
   ) {
+    this.client = new Nanoleaf4DClient(this.log.error.bind(this.log));
     this.log('Starting Nanoleaf4DPlatform');
     this.Service = api.hap.Service;
     this.Characteristic = api.hap.Characteristic;

--- a/src/ui/plugin-ui-server.mts
+++ b/src/ui/plugin-ui-server.mts
@@ -3,7 +3,7 @@ import { Nanoleaf4DClient } from '../nanoleaf4DClient.mjs';
 import { Nanoleaf4DInstance, PairedNanoleaf4DInstance } from '../configuration-types.js';
 
 export class Nanoleaf4DPluginUiServer extends HomebridgePluginUiServer {
-  private readonly client = new Nanoleaf4DClient();
+  private readonly client = new Nanoleaf4DClient(console.error);
     
   constructor() {
     super();


### PR DESCRIPTION
## Summary
- add logger-based error handling for fetch calls
- pass logger to Nanoleaf4DClient
- handle network errors when pairing and identifying devices

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68773c1a45a8832f8b65868127693531